### PR TITLE
Nisse improvement

### DIFF
--- a/include/Nisse.h
+++ b/include/Nisse.h
@@ -76,6 +76,12 @@ private:
   /// \return The casted value.
   llvm::Value *createInt32Cast(llvm::Value *inst, llvm::IRBuilder<> &builder);
 
+  /// \brief Casts a value to i64.
+  /// \param inst The value to cast.
+  /// \param builder The builder where to insert the cast.
+  /// \return The casted value.
+  llvm::Value *createInt64Cast(llvm::Value *inst, llvm::IRBuilder<> &builder);
+
   /// \brief Computes the hook to insert the KS counter.
   /// If the source block terminates with an absolute jump, the counter is
   /// placed at the end of that block. If not, it is placed at the start of the

--- a/include/Nisse.h
+++ b/include/Nisse.h
@@ -372,6 +372,15 @@ struct KSAnalysis : public llvm::AnalysisInfoMixin<KSAnalysis> {
 
 /// \brief Instruments a function for KS edge instrumentation.
 struct KSPass : public NissePass {
+private:
+  llvm::GlobalVariable *CounterArray = nullptr;
+  llvm::GlobalVariable *IndexArray = nullptr;
+  std::map<std::string, int> FunctionSize;
+  int NumEdges = 0;
+  int Offset = 0;
+  std::ofstream outfile;
+
+public:
   /// \brief The transformation pass' run function. Instruments the function
   /// given as argument for KS edge instrumentation.
   /// \param F The function to transform.

--- a/include/Nisse.h
+++ b/include/Nisse.h
@@ -31,6 +31,7 @@
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/PassManager.h"
 #include <map>
+#include <fstream>
 
 namespace nisse {
 
@@ -315,6 +316,14 @@ public:
 ///
 /// \brief Instruments a function for edge instrumentation.
 struct NissePass : public llvm::PassInfoMixin<NissePass> {
+private:
+  llvm::GlobalVariable *CounterArray = nullptr;
+  llvm::GlobalVariable *IndexArray = nullptr;
+  std::map<std::string, int> FunctionSize;
+  int NumEdges = 0;
+  int Offset = 0;
+  std::ofstream outfile;
+
 protected:
   /// \brief Inserts the initialization code, which creates a
   /// 0-initialized array of ints of size size.
@@ -330,7 +339,7 @@ protected:
   /// \param counterInst The instruction pointer to the counter array.
   /// \param indexInst The instruction pointer to the index array.
   /// \param size The size of the counter and index arrays.
-  void insertExitFn(llvm::Function &F, llvm::Value *counterInst,
+  void insertExitFn(llvm::Module &M, llvm::Function &F, llvm::Value *counterInst,
                     llvm::Value *indexInst, int size);
 
 public:
@@ -338,8 +347,8 @@ public:
   /// given as argument for KS edge instrumentation.
   /// \param F The function to transform.
   /// \param FAM The current FunctionAnalysisManager.
-  llvm::PreservedAnalyses run(llvm::Function &F,
-                              llvm::FunctionAnalysisManager &FAM);
+  llvm::PreservedAnalyses run(llvm::Module &F,
+                              llvm::ModuleAnalysisManager &FAM);
 };
 
 /// \brief Computes the maximum spanning tree of a function's CFG
@@ -367,8 +376,8 @@ struct KSPass : public NissePass {
   /// given as argument for KS edge instrumentation.
   /// \param F The function to transform.
   /// \param FAM The current FunctionAnalysisManager.
-  llvm::PreservedAnalyses run(llvm::Function &F,
-                              llvm::FunctionAnalysisManager &FAM);
+  llvm::PreservedAnalyses run(llvm::Module &M,
+                              llvm::ModuleAnalysisManager &MAM);
 };
 
 } // namespace nisse

--- a/ks_profiler.sh
+++ b/ks_profiler.sh
@@ -31,6 +31,9 @@ BS_NAME=$(basename $FL_NAME .c)
 PROF_DIR=$FL_NAME.profiling
 LL_NAME="$BS_NAME.ll"
 PF_NAME="$BS_NAME.profiled.ll"
+INFO_PROF="info.prof"
+MAIN_PROF="main.prof"
+PROF_SUF=".prof.full"
 
 
 # Create the profiling folder:
@@ -65,7 +68,6 @@ $LLVM_OPT -S -passes="dot-cfg" -stats \
     $PF_NAME -o $PF_NAME
 
 # Compile the newly instrumented program, and link it against the profiler.
-# We are passing -no_pie to disable address space layout randomization:
 #
 $LLVM_CLANG -Wall -std=c99 $PF_NAME $PROFILER_IMPL -o $BS_NAME
 ret_code=$?
@@ -79,28 +81,22 @@ fi
 # Run the instrumented binary:
 #
 ./$BS_NAME 0
-
-# Prepare the result folders
-#
-mkdir graphs profiles compiled partial_profiles dot
-
-# Propagation Flags to use:
-#
-if [ $# -eq 2 ]
+ret_code=$?
+if [ ! -f $INFO_PROF ] || [ ! -f $MAIN_PROF ]
 then
-  PROP_FLAG="-s"
-else
-  PROP_FLAG=""
+  echo "Execution failed"
+  cd -
+  echo $FL_NAME >> err.txt
+  exit $ret_code
 fi
 
 # Propagate the weights for each function:
 #
-for i in *.prof; do
-  PROF_NAME="$i.full"
-  $PROP_BIN $i $PROP_FLAG -o $PROF_NAME
-  mv $i partial_profiles/
-  mv $PROF_NAME profiles/
-done
+$PROP_BIN $INFO_PROF $MAIN_PROF -o ".prof.full"
+
+# Prepare the result folders
+#
+mkdir graphs profiles compiled partial_profiles dot
 
 # Move the files to apropriate folders
 #
@@ -114,6 +110,14 @@ done
 
 for i in *.ll; do
   mv $i compiled/
+done
+
+for i in *.prof.full*; do
+  mv $i profiles/
+done
+
+for i in *.prof; do
+  mv $i partial_profiles/
 done
 
 mv $BS_NAME compiled/

--- a/ks_profiler.sh
+++ b/ks_profiler.sh
@@ -69,6 +69,7 @@ $LLVM_OPT -S -passes="dot-cfg" -stats \
 
 # Compile the newly instrumented program, and link it against the profiler.
 #
+$LLVM_OPT -S -passes="loop-simplify,break-crit-edges" $LL_NAME -o $LL_NAME
 $LLVM_CLANG -Wall -std=c99 $PF_NAME $PROFILER_IMPL -o $BS_NAME
 ret_code=$?
 if [[ $ret_code -ne 0 ]]; then
@@ -80,7 +81,12 @@ fi
 
 # Run the instrumented binary:
 #
-./$BS_NAME 0
+if [ $# -ge 2 ]
+then
+  ./$BS_NAME $2
+else
+  ./$BS_NAME 0
+fi
 ret_code=$?
 if [ ! -f $INFO_PROF ] || [ ! -f $MAIN_PROF ]
 then

--- a/lib/NisseAnalysis.cpp
+++ b/lib/NisseAnalysis.cpp
@@ -270,6 +270,7 @@ void NisseAnalysis::identifyWellFoundedEdges(Loop *L, ScalarEvolution &SE,
   SmallVector<BlockPtr> exitBlocks;
   L->getExitBlocks(exitBlocks);
   auto firstBlock = incomingBlock->getSingleSuccessor();
+  if (firstBlock == nullptr) return;
   Edge backEdge(backBlock, firstBlock, -1);
   for (auto &PHI : firstBlock->phis()) {
     if (identifyInductionVariable(SE, edges, &PHI, incomingBlock, backBlock,

--- a/lib/NissePass.cpp
+++ b/lib/NissePass.cpp
@@ -116,7 +116,7 @@ PreservedAnalyses NissePass::run(Module &M, ModuleAnalysisManager &MAM) {
   outfile.close();
 
   // Initialize global variables
-  ArrayType *CounterArrayType = ArrayType::get(Type::getInt32Ty(Ctx), NumEdges);
+  ArrayType *CounterArrayType = ArrayType::get(Type::getInt64Ty(Ctx), NumEdges);
   CounterArray = new GlobalVariable(
     M, CounterArrayType, false, GlobalValue::ExternalLinkage,
     Constant::getNullValue(CounterArrayType), "counter-array"
@@ -195,7 +195,7 @@ PreservedAnalyses KSPass::run(Module &M, ModuleAnalysisManager &MAM) {
   outfile.close();
 
   // Initialize global variables
-  ArrayType *CounterArrayType = ArrayType::get(Type::getInt32Ty(Ctx), NumEdges);
+  ArrayType *CounterArrayType = ArrayType::get(Type::getInt64Ty(Ctx), NumEdges);
   CounterArray = new GlobalVariable(
     M, CounterArrayType, false, GlobalValue::ExternalLinkage,
     Constant::getNullValue(CounterArrayType), "counter-array"

--- a/lib/NissePlugin.cpp
+++ b/lib/NissePlugin.cpp
@@ -41,20 +41,21 @@ void registerAnalyses(FunctionAnalysisManager &FAM) {
 ///
 /// \returns true if \p Name corresponds to any of the passes implemented;
 /// otherwise, returns false.
-bool registerPipeline(StringRef Name, FunctionPassManager &FPM,
+bool registerPipeline(StringRef Name, ModulePassManager &MPM,
                       ArrayRef<PassBuilder::PipelineElement>) {
-
   if (Name == "nisse") {
+    FunctionPassManager FPM;
     FPM.addPass(LoopSimplifyPass());
     FPM.addPass(BreakCriticalEdgesPass());
-    FPM.addPass(nisse::NissePass());
+    MPM.addPass(nisse::NissePass());
     return true;
   }
 
   if (Name == "ks") {
+    FunctionPassManager FPM;
     FPM.addPass(LoopSimplifyPass());
     FPM.addPass(BreakCriticalEdgesPass());
-    FPM.addPass(nisse::KSPass());
+    MPM.addPass(nisse::KSPass());
     return true;
   }
 

--- a/lib/NissePlugin.cpp
+++ b/lib/NissePlugin.cpp
@@ -43,18 +43,13 @@ void registerAnalyses(FunctionAnalysisManager &FAM) {
 /// otherwise, returns false.
 bool registerPipeline(StringRef Name, ModulePassManager &MPM,
                       ArrayRef<PassBuilder::PipelineElement>) {
+
   if (Name == "nisse") {
-    FunctionPassManager FPM;
-    FPM.addPass(LoopSimplifyPass());
-    FPM.addPass(BreakCriticalEdgesPass());
     MPM.addPass(nisse::NissePass());
     return true;
   }
 
   if (Name == "ks") {
-    FunctionPassManager FPM;
-    FPM.addPass(LoopSimplifyPass());
-    FPM.addPass(BreakCriticalEdgesPass());
     MPM.addPass(nisse::KSPass());
     return true;
   }

--- a/lib/prof.c
+++ b/lib/prof.c
@@ -2,7 +2,7 @@
 #include <string.h>
 #include <unistd.h>
 
-void nisse_pass_print_data(int *count_array, int *index_array, int size) {
+void nisse_pass_print_data(long long *count_array, int *index_array, int size) {
   if (access("main.prof", F_OK) != 0) {
     printf("Writing '%s'...\n", "main.prof");
   }
@@ -11,16 +11,9 @@ void nisse_pass_print_data(int *count_array, int *index_array, int size) {
     perror("Could not open file");
     return;
   }
-  // fwrite(&size, sizeof(int), 1, file);
-  // fwrite(index_array, sizeof(long long), size, file);
-  // fwrite(count_array, sizeof(int), size, file);
-  // fprintf(file, "%s%s%s\n", line, function_name, line);
+  
   for (int i = 0; i < size; i++) {
-    // fwrite(&index_array[i], sizeof(int), 1, file);
-    // fwrite(&count_array[i], sizeof(int), 1, file);
-    // int numbers[2] = {index_array[i], count_array[i]};
-    // fwrite(numbers, sizeof(int), sizeof(numbers)/sizeof(int), file);
-    fprintf(file, "%d %d\n", index_array[i], count_array[i]);
+    fprintf(file, "%d %Ld\n", index_array[i], count_array[i]);
   } 
   fclose(file);
 }

--- a/lib/prof.c
+++ b/lib/prof.c
@@ -2,33 +2,25 @@
 #include <string.h>
 #include <unistd.h>
 
-void print_data(char *function_name, int function_size, int *count_array,
-                int *index_array, int size) {
-  char output_name[64];
-  char ext[] = ".prof";
-  char line[] = "-------------------------------";
-  memset(output_name, '\0', 64);
-  memcpy(output_name, function_name, function_size);
-  strcat(output_name, ext);
-
-  if (access(output_name, F_OK) != 0) {
-    printf("Writing '%s'...\n", output_name);
+void nisse_pass_print_data(int *count_array, int *index_array, int size) {
+  if (access("main.prof", F_OK) != 0) {
+    printf("Writing '%s'...\n", "main.prof");
   }
-  FILE *file = fopen(output_name, "ab");
+  FILE *file = fopen("main.prof", "a");
   if (!file) {
     perror("Could not open file");
     return;
   }
-  fwrite(&size, sizeof(int), 1, file);
-  fwrite(index_array, sizeof(int), size, file);
-  fwrite(count_array, sizeof(int), size, file);
+  // fwrite(&size, sizeof(int), 1, file);
+  // fwrite(index_array, sizeof(long long), size, file);
+  // fwrite(count_array, sizeof(int), size, file);
   // fprintf(file, "%s%s%s\n", line, function_name, line);
-  // for (int i = 0; i < size; i++) {
+  for (int i = 0; i < size; i++) {
     // fwrite(&index_array[i], sizeof(int), 1, file);
     // fwrite(&count_array[i], sizeof(int), 1, file);
     // int numbers[2] = {index_array[i], count_array[i]};
     // fwrite(numbers, sizeof(int), sizeof(numbers)/sizeof(int), file);
-    // fprintf(file, "%d %d\n", index_array[i], count_array[i]);
-  // } 
+    fprintf(file, "%d %d\n", index_array[i], count_array[i]);
+  } 
   fclose(file);
 }

--- a/nisse_profiler.sh
+++ b/nisse_profiler.sh
@@ -32,6 +32,9 @@ BS_NAME=$(basename $FL_NAME .c)
 PROF_DIR=$FL_NAME.profiling
 LL_NAME="$BS_NAME.ll"
 PF_NAME="$BS_NAME.profiled.ll"
+INFO_PROF="info.prof"
+MAIN_PROF="main.prof"
+PROF_SUF=".prof.full"
 
 
 # Create the profiling folder:
@@ -65,8 +68,7 @@ $LLVM_OPT -S -load-pass-plugin $MY_LLVM_LIB -passes="nisse" -stats \
 $LLVM_OPT -S -passes="dot-cfg" -stats \
     $PF_NAME -o $PF_NAME
 
-# Compile the newly instrumented program, and link it against the profiler.
-# We are passing -no_pie to disable address space layout randomization:
+# Compile the newly instrumented program, and link it against the profiler
 #
 $LLVM_CLANG -Wall -std=c99 $PF_NAME $PROFILER_IMPL -o $BS_NAME
 ret_code=$?
@@ -80,29 +82,22 @@ fi
 # Run the instrumented binary:
 #
 ./$BS_NAME 3
-
-# Prepare the result folders
-#
-mkdir graphs profiles compiled partial_profiles dot
-
-# Propagation Flags to use:
-#
-if [ $# -eq 2 ]
+ret_code=$?
+if [ ! -f $INFO_PROF ] || [ ! -f $MAIN_PROF ]
 then
-  PROP_FLAG="-s"
-else
-  PROP_FLAG=""
+  echo "Execution failed"
+  cd -
+  echo $FL_NAME >> err.txt
+  exit $ret_code
 fi
 
 # Propagate the weights for each function:
 #
-for i in *.prof; do
-  PROF_NAME="$i.full"
-  $PROP_BIN $i $PROP_FLAG -o $PROF_NAME
-  mv $i partial_profiles/
-  mv $PROF_NAME.edges profiles/
-  mv $PROF_NAME.bb profiles/
-done
+$PROP_BIN $INFO_PROF $MAIN_PROF -o ".prof.full"
+
+# Prepare the result folders
+#
+mkdir graphs profiles compiled partial_profiles dot
 
 # Move the files to apropriate folders
 #
@@ -116,6 +111,14 @@ done
 
 for i in *.ll; do
   mv $i compiled/
+done
+
+for i in *.prof.full*; do
+  mv $i profiles/
+done
+
+for i in *.prof; do
+  mv $i partial_profiles/
 done
 
 mv $BS_NAME compiled/

--- a/nisse_profiler.sh
+++ b/nisse_profiler.sh
@@ -60,6 +60,7 @@ $LLVM_OPT -S -passes="mem2reg,instnamer" $LL_NAME -o $LL_NAME
 
 # Running the pass:
 #
+$LLVM_OPT -S -passes="loop-simplify,break-crit-edges" $LL_NAME -o $LL_NAME
 $LLVM_OPT -S -load-pass-plugin $MY_LLVM_LIB -passes="nisse" -stats \
     $LL_NAME -o $PF_NAME
 
@@ -81,7 +82,12 @@ fi
 
 # Run the instrumented binary:
 #
-./$BS_NAME 3
+if [ $# -ge 2 ]
+then
+  ./$BS_NAME $2
+else
+  ./$BS_NAME 0
+fi
 ret_code=$?
 if [ ! -f $INFO_PROF ] || [ ! -f $MAIN_PROF ]
 then

--- a/src/NissePropagation.cpp
+++ b/src/NissePropagation.cpp
@@ -31,16 +31,18 @@
 using namespace std;
 using namespace llvm;
 
-/// \brief Shorthand for vector of int.
-using vi = vector<int>;
-/// \brief Shorthand for vector of vector of int.
+/// \brief Shorthand for long long int
+using ll = long long int;
+/// \brief Shorthand for vector of long long int.
+using vi = vector<ll>;
+/// \brief Shorthand for vector of vector of long long int.
 using vvi = vector<vi>;
-/// \brief Shorthand for vector of pairs of int.
-using vpi = vector<pair<int, int>>;
-/// \brief Shorthand for set of int.
-using si = set<int>;
-/// \brief Shorthand for map from int to set of int.
-using msi = map<int, si>;
+/// \brief Shorthand for vector of pairs of long long int.
+using vpi = vector<pair<ll, ll>>;
+/// \brief Shorthand for set of long long int.
+using si = set<ll>;
+/// \brief Shorthand for map from int to set of long long int.
+using msi = map<ll, si>;
 
 using vs = vector<string>;
 using mss = map<string, si>;
@@ -144,33 +146,6 @@ vi initWeights(string input, vpi &prof, int edgeCount, int instCount, bool debug
     weights[edge] = weight;
   }
 
-  // ifstream prof;
-  // string buf;
-  // prof.open(input + ".prof", std::ios::binary);
-  // // FILE *file = fopen((input+".prof").c_str(), "rb");
-  // int sz;
-
-  // // while (fread(&sz, sizeof(int), 1, file) == 1) {
-  // //   int index_array[sz], count_array[sz];
-  // //   fread(index_array, sizeof(int), sz, file);
-  // //   fread(count_array, sizeof(int), sz, file);
-  // //   for (auto i = 0; i < instCount; i++) {
-  // //     int edge, weight;
-  // //     edge = index_array[i];
-  // //     weight = count_array[i];
-  // //     // fread(&edge, sizeof(int), 1, file);
-  // //     // fread(&weight, sizeof(int), 1, file);
-  // //     weights[edge] += weight;
-  // //   }
-  // // }
-  // while (prof >> sz) {
-  //   for (auto i = 0; i < instCount; i++) {
-  //     int edge, weight;
-  //     prof >> edge >> weight;
-  //     weights[edge] += weight;
-  //   }
-  // }
-
   if (debug) {
     for (auto i : weights) {
       cout << i << " ";
@@ -178,54 +153,6 @@ vi initWeights(string input, vpi &prof, int edgeCount, int instCount, bool debug
     cout << endl;
   }
 
-  // prof.close();
-  // fclose(file);
-  return weights;
-}
-
-/// \brief Initialises the edge weights based on the input file. If there are
-/// multiple profilings, will sum create a separate set of weights for each.
-/// \param input Path to the input file.
-/// \param edgeCount Number of edges in the graph.
-/// \param instCount Number of instrumented edges.
-/// \param debug Flag for the debug messages.
-/// \return The weights of the edges, initialized at 0, or at the values given
-/// in the input file.
-vvi initWeightsSeparate(string input, int edgeCount, int instCount,
-                        bool debug) {
-  vvi weights;
-  // ifstream prof;
-  // string buf;
-  // prof.open(input + ".prof");
-  FILE *file = fopen((input+".prof").c_str(), "rb");
-  int sz;
-
-  while (fread(&sz, sizeof(int), 1, file) == 1) {
-    vi w(edgeCount, 0);
-    int index_array[sz], count_array[sz];
-    fread(index_array, sizeof(int), sz, file);
-    fread(count_array, sizeof(int), sz, file);
-    for (auto i = 0; i < instCount; i++) {
-      int edge, weight;
-      edge = index_array[i];
-      weight = count_array[i];
-      // prof >> edge >> weight;
-      w[edge] = weight;
-    }
-    weights.push_back(w);
-  }
-
-  if (debug) {
-    for (auto w : weights) {
-      for (auto i : w) {
-        cout << i << " ";
-      }
-      cout << endl;
-    }
-  }
-
-  // prof.close();
-  fclose(file);
   return weights;
 }
 
@@ -240,7 +167,7 @@ vvi initWeightsSeparate(string input, int edgeCount, int instCount,
 /// function).
 void propagation(vps &edges, si &ST, mss &in, mss &out, vi &weights, string v,
                  int e = -1) {
-  int in_sum = 0;
+  ll in_sum = 0;
   for (auto ep : in[v]) {
     if (ep != e && ST.count(ep) == 1) {
       propagation(edges, ST, in, out, weights, edges[ep].first, ep);
@@ -248,7 +175,7 @@ void propagation(vps &edges, si &ST, mss &in, mss &out, vi &weights, string v,
     in_sum += weights[ep];
   }
 
-  int out_sum = 0;
+  ll out_sum = 0;
   for (auto ep : out[v]) {
     if (ep != e && ST.count(ep) == 1) {
       propagation(edges, ST, in, out, weights, edges[ep].second, ep);
@@ -302,7 +229,7 @@ void outputFile(string filename, vps &edges, vi &weights) {
     outputCout(edges, weights);
   }
 
-  map<string,int> bbFrequency;
+  map<string,ll> bbFrequency;
   for (int i = 0; i < size; i++) {
     // if (edges[i].first == "0") bbFrequency["0"] += weights[i];
     bbFrequency[edges[i].second] += weights[i];
@@ -334,6 +261,7 @@ int main(int argc, char **argv) {
       "s", cl::desc("Do separate profilings for each function execution"));
 
   cl::ParseCommandLineOptions(argc, argv);
+  vector<string> functions;
   map<string, int> functionSizes;
   map<string, vpi> functionProfiles;
   
@@ -343,6 +271,7 @@ int main(int argc, char **argv) {
     string function_name;
     int sz;
     while (info_file >> function_name >> sz) {
+      functions.emplace_back(function_name);
       functionSizes[function_name] = sz;
     }
     info_file.close();
@@ -352,10 +281,11 @@ int main(int argc, char **argv) {
   {
     ifstream prof_file;
     prof_file.open(ProfFilename);
-    for (auto [function_name, sz] : functionSizes) {
+    for (auto function_name : functions) {
+      auto sz = functionSizes[function_name];
       functionProfiles[function_name] = {};
       while (sz--) {
-        int idx, count;
+        ll idx, count;
         prof_file >> idx >> count;
         functionProfiles[function_name].emplace_back(idx, count);
       }
@@ -363,21 +293,14 @@ int main(int argc, char **argv) {
     prof_file.close();
   }
 
-  for (auto [function_name, prof] : functionProfiles) {
+  for (auto function_name : functions) {
+    auto prof = functionProfiles[function_name];
+
     vs vertex;
     vps edges;
     si ST, revST;
     mss in, out;
     vvi weights;
-
-    // int period = InputFilename.find_last_of('.');
-    // int slash = InputFilename.find_last_of('/');
-    // string input;
-    // if (period > slash) {
-    //   input = InputFilename.substr(0, period);
-    // } else {
-    //   input = InputFilename.getValue();
-    // }
 
     if (Debug) {
       cout << "\nComputing the graph of " << function_name << "\n\n";
@@ -389,11 +312,7 @@ int main(int argc, char **argv) {
       cout << "\nComputing the input weights\n\n";
     }
 
-    if (Separate) {
-      weights = initWeightsSeparate(function_name, edges.size(), revST.size(), Debug);
-    } else {
-      weights.push_back(initWeights(function_name, prof, edges.size(), revST.size(), Debug));
-    }
+    weights.push_back(initWeights(function_name, prof, edges.size(), revST.size(), Debug));
 
     if (Debug) {
       cout << "\nPropagating the weights\n\n";


### PR DESCRIPTION
Reducing the number of times that Nisse profiler dumps a profile down to one, right before exiting the main function.
In this way, there is a significant improvement in performance, since there will be less print commands during the execution of the binary. Such improvements are more visible in recursive functions that creates multiple calls to itself, like a recursive Fibonacci function without memoization.